### PR TITLE
Add json_safe method to Response class

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,7 @@
 * `def .raise_for_status()` - **Response**
 * `def .json()` - **Any**
 * `def .read()` - **bytes**
-* `def .json_safe([default])` - **Any**
+* `def .json_safe()` - **Any**
 
 * `def .iter_raw([chunk_size])` - **bytes iterator**
 * `def .iter_bytes([chunk_size])` - **bytes iterator**

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,6 +73,8 @@
 * `def .raise_for_status()` - **Response**
 * `def .json()` - **Any**
 * `def .read()` - **bytes**
+* `def .json_safe([default])` - **Any**
+
 * `def .iter_raw([chunk_size])` - **bytes iterator**
 * `def .iter_bytes([chunk_size])` - **bytes iterator**
 * `def .iter_text([chunk_size])` - **text iterator**


### PR DESCRIPTION
This commit adds a new json_safe() method to the Response class that provides graceful error handling for JSON parsing. Unlike the standard json() method, json_safe() returns a default value instead of raising exceptions when:
- The response body is empty
- The response contains invalid JSON
- Unicode decode errors occur

The method also supports an optional raise_for_status parameter to validate HTTP status codes before parsing, making it easier to handle API responses that may fail or return malformed data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Thanks for contributing to HTTPX! 💚
Given this is a project maintained by volunteers, please read this template to not waste your time, or ours! 😁 -->

# Summary

<!-- Write a small summary about what is happening here. -->

# Checklist

- [ ] I understand that this PR may be closed in case there was no previous discussion. (This doesn't apply to typos!)
- [ ] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [ ] I've updated the documentation accordingly.
